### PR TITLE
ツモ牌を左に変更

### DIFF
--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -24,7 +24,7 @@ const chats = ref([]);
 
 const drawFlag = ref(false);
 const riichiFlag = ref(false);
-const voteFlag = ref(false);
+const voteFlag = ref(true);
 const votedFlag = ref(false);
 const selectCount = ref(0);
 const chatFlag = ref(false);
@@ -791,7 +791,7 @@ socket.on("update_reaction", (received_reaction) => {
 
 .bottom-content {
   top: 90%;
-  left: 50%;
+  right: 6%;
   transform: translate(-50%, -50%);
 }
 
@@ -1024,12 +1024,15 @@ button:hover {
 
 .tsumo {
   /* display: inline-block; */
-  margin-left: 1vw;
+  /* margin-left: 3vw; */
+  position: absolute;
+  right: 106%;
 }
 
 .calls {
   /* display: inline-block; */
-  margin-left: 1vw;
+  margin-left: 6vw;
+  margin-right: -5.5vw;
 }
 
 .pon {

--- a/client/src/views/Game.vue
+++ b/client/src/views/Game.vue
@@ -24,7 +24,7 @@ const chats = ref([]);
 
 const drawFlag = ref(false);
 const riichiFlag = ref(false);
-const voteFlag = ref(true);
+const voteFlag = ref(false);
 const votedFlag = ref(false);
 const selectCount = ref(0);
 const chatFlag = ref(false);


### PR DESCRIPTION
#74 
ツモを左に揃えました。
ポンも右に感覚を詰めて揃うようにしました。
<img width="1440" alt="スクリーンショット 2023-09-02 9 35 55" src="https://github.com/KITA-DS12/koi-jan/assets/119462670/10d963d0-7f49-45b5-8729-13002eed17da">
<img width="1440" alt="スクリーンショット 2023-09-02 9 36 03" src="https://github.com/KITA-DS12/koi-jan/assets/119462670/ba39e89b-f682-435a-b3b0-1529a70e8b85">
